### PR TITLE
crypto package, Sha1 collisions, using, hash2map

### DIFF
--- a/src/BytesUtil.hx
+++ b/src/BytesUtil.hx
@@ -109,7 +109,7 @@ class BytesUtil {
 	**/
 	public static function encodeToBase(buf:Bytes,base:String) : Bytes
 	{
-		var bc = new haxe.BaseCode( Bytes.ofString(base) );
+		var bc = new haxe.crypto.BaseCode( Bytes.ofString(base) );
 		return bc.encodeBytes(buf);
 	}
 

--- a/src/chx/hash/Sha1_.hx
+++ b/src/chx/hash/Sha1_.hx
@@ -37,11 +37,11 @@ package chx.hash;
 
 import haxe.io.Bytes;
 import haxe.io.BytesBuffer;
-import haxe.SHA1;
+import haxe.crypto.Sha1;
 
 import BytesUtil;
 
-class Sha1 implements IHash {
+class Sha1_ implements IHash {
 
     public function new() {
 	}
@@ -79,7 +79,7 @@ class Sha1 implements IHash {
 
 
 	public function encode(msg:Bytes) : Bytes {
-	    return Bytes.ofString(SHA1.encode( msg.readString(0,msg.length)));
+	    return Bytes.ofString(Sha1.encode( msg.readString(0,msg.length)));
 	}
 
 }

--- a/src/hxoauth/OAuth.hx
+++ b/src/hxoauth/OAuth.hx
@@ -1,12 +1,14 @@
 package hxoauth;
 import chx.hash.HMAC;
-import chx.hash.Sha1;
+import chx.hash.Sha1_;
 import haxe.Http;
 import haxe.Int32;
 import haxe.io.Bytes;
 import haxe.Timer;
 import utils.Base64;
 import haxe.Json;
+
+using Lambda ;
 
 /**
  * OAuth2 Client for haxe, currently supporting:
@@ -30,7 +32,6 @@ enum HTTPMethod {
 	
 }
 
-using Lambda ;
 
 /**
  * Main client to initialize the client
@@ -138,7 +139,7 @@ class Request
 
 	private var method : HTTPMethod ;
 
-	private var credentials : Hash<String> ;
+	private var credentials : Map<String, String> ;
 
 	private var signature : SignatureMethod ;
 
@@ -169,7 +170,7 @@ class Request
         // TODO clean the below up
 		signature = HMAC_SHA1 ;
 
-		credentials = new Hash<String>() ;
+		credentials = new Map<String, String>() ;
 		/*
 		credentials.set( "cli", _consumer.key ) ;
 		credentials.set( "oauth_token", _token ) ;
@@ -195,7 +196,7 @@ class Request
 				trace( text ) ;
 				var key = encode( consumer.secret ) + '&' + encode( token ) ;
 				trace( key ) ;
-				var hash = new HMAC( new Sha1() ) ;
+				var hash = new HMAC( new Sha1_() ) ;
 				var bytes = hash.calculate( Bytes.ofString(key), Bytes.ofString(text) );
 				trace( bytes.toHex() ) ;
 				var digest = Base64.encode( bytes.toString() ) ;
@@ -419,7 +420,7 @@ class Request
 
 		#if neko
 		var t = Std.int( Timer.stamp() ) ;
-		return Int32.make( ( t >> 16 ) & 0x7FFF, t & 0xFFFF ) ;
+		return ( t << 16 | t & 0xFFFF );
 		#else
 		return Int32.ofInt( Std.int( Timer.stamp() ) ) ;
 		#end

--- a/src/utils/Base64.hx
+++ b/src/utils/Base64.hx
@@ -5,7 +5,7 @@
  */
 
 package utils;
-import haxe.BaseCode;
+import haxe.crypto.BaseCode;
 import haxe.io.Bytes;
 
 // IMPORTS
@@ -50,7 +50,9 @@ class Base64
 		else if ( complement == 2 )
 			"="
 		else if ( complement == 1 )
-			"==";		
+			"==";
+		else
+			throw("Complement error");
 	}
 	
 }

--- a/test/OAuthTest.hx
+++ b/test/OAuthTest.hx
@@ -2,7 +2,7 @@ package ;
 
 import chx.hash.HMAC;
 import chx.hash.Sha1;
-import haxe.SHA1;
+import haxe.crypto.SHA1;
 // import neko.Lib;
 import hxoauth.OAuth;
 import utils.Base64;


### PR DESCRIPTION
FIXED haxe.BaseCode to haxe.crypto.Basecode
FIXED haxe.SHA1 to haxe.crypto.Sha1;
FIXED Sha1 to Sha1_ => naming collisions
FIXED "using" was written after a class
FIXED Hash<String> to Map<String, String>

Upgraded the library to make it work with haxe 3.1.2
